### PR TITLE
Added New Coding Syntax

### DIFF
--- a/code_translator.py
+++ b/code_translator.py
@@ -17,6 +17,7 @@ class Translator:
 
         self.python_code = ''
         self.indentation = '\t'
+        self.indent = 0
 
         self.start_keywords = START_KEYWORDS.copy()
         self.end_keywords = END_KEYWORDS.copy()
@@ -30,30 +31,31 @@ class Translator:
             if json_code is None:
                 json_code = self.json_code
 
+            if isinstance(json_code, str):
+                json_code = read_json(json_code)
+
             converted_code = ''
-            indent = 0
             for key, value in json_code.items():
                 # * KEYWORD VALIDATION
                 pattern = r'[a-zA-Z]+'
                 start_term = re.search(pattern, key)
                 start_term = str(start_term.group())
-                current_indentation = self.indentation * indent
+                current_indentation = self.indentation * self.indent
 
                 if start_term not in self.all_keywords:
                     raise Exception(f'Keyword {key} is not supported')
 
-                if indent < 0:
+                if self.indent < 0:
                     raise Exception('Indentation is less than 0')
 
                 # * START TRANSLATION
 
                 # Process block keywords by recursively calling the convert function
                 if start_term in self.block_keywords:
-                    converted_code += (
-                        f'{self.block_keywords[start_term]}'
-                        f'{self.convert(value)[1]}'
-                        f'{self.block_keywords[start_term]}'
-                    )
+                    converted_code += f'{current_indentation}{self.block_keywords[start_term] % value[0]}'
+                    self.indent += 1
+                    converted_code += f'{self.convert(value[1])[1]}\n'
+                    self.indent -= 1
                     continue
 
                 # Check if the current line is a calculation
@@ -69,9 +71,9 @@ class Translator:
 
                 # * INDENTATION HANDLING
                 if start_term in self.start_keywords:
-                    indent += 1
+                    self.indent += 1
                 elif start_term in self.end_keywords:
-                    indent -= 1
+                    self.indent -= 1
 
             return 'success', converted_code
 

--- a/example/short_syntax.json
+++ b/example/short_syntax.json
@@ -2,12 +2,11 @@
   "code": {
     "cmt1": "Write a program that calc fibo",
 
-    "func": [
-      "fibo",
-      ["n"],
+    "func1": [
+      "fibo(n)",
       {
         "if1": ["n < 2", { "ret:": "n" }],
-        "el1": { "ret": "fibo(n-1) + fibo(n-2)" }
+        "el1": ["", { "ret": "fibo(n-1) + fibo(n-2)" }]
       }
     ],
 

--- a/example/short_syntax.json
+++ b/example/short_syntax.json
@@ -1,15 +1,23 @@
 {
   "code": {
-    "cmt1": "Swap 2 numbers using shortcut syntaxes",
-    "int1": ["a", 5],
-    "int2": ["b", 10],
-    "blk1": {
-      "cmt1": "Swap using temp variable",
-      "int1": ["temp", "a"],
-      "int2": ["a", "b"],
-      "int3": ["b", "temp"]
-    },
-    "out": "f'After swapping, a = {a} and b = {b}'"
+    "cmt1": "Write a program that calc fibo",
+
+    "func": [
+      "fibo",
+      ["n"],
+      {
+        "if1": ["n < 2", { "ret:": "n" }],
+        "el1": { "ret": "fibo(n-1) + fibo(n-2)" }
+      }
+    ],
+
+    "cmt2": "Test for fibo from a to b",
+    "int1": ["a", "1"],
+    "int2": ["b", "6"],
+    "for1": [
+      "i in range(a, b + 1)",
+      { "out": "f'fibo({i}) = {fibo(i)}'" }
+    ]
   },
   "filename": "code.py"
 }

--- a/pyjson.config.json
+++ b/pyjson.config.json
@@ -8,6 +8,7 @@
     "for": "for %s:",
     "while": "while %s:",
     "if": "if %s:",
+    "elif": "elif %s:",
     "else": "else: %s",
     "func": "def %s:",
     "class": "class %s:"
@@ -16,6 +17,7 @@
     "endfor": "%s",
     "endwhile": "%s",
     "endif": "%s",
+    "endelif": "%s",
     "endelse": "%s",
     "endfunc": "%s",
     "endclass": "%s"
@@ -27,6 +29,12 @@
     "bool": "%s = bool(%s)"
   },
   "BLOCK_KEYWORDS": {
-    "block": "\n"
+    "for": "for %s:\n",
+    "while": "while %s:\n",
+    "if": "if %s:\n",
+    "elif": "elif %s:\n",
+    "else": "else: %s\n",
+    "function": "def %s:\n",
+    "class": "class %s:\n"
   }
 }

--- a/pyjson.shortcut.json
+++ b/pyjson.shortcut.json
@@ -21,12 +21,6 @@
     "efunc": "%s",
     "ecls": "%s"
   },
-  "VAR_KEYWORDS": {
-    "int": "%s = int(%s)",
-    "str": "%s = str(%s)",
-    "float": "%s = float(%s)",
-    "bool": "%s = bool(%s)"
-  },
   "BLOCK_KEYWORDS": {
     "el": "else: %s\n",
     "func": "def %s:\n",

--- a/pyjson.shortcut.json
+++ b/pyjson.shortcut.json
@@ -16,6 +16,7 @@
     "efor": "%s",
     "ewhile": "%s",
     "eif": "%s",
+    "eelif": "%s",
     "eelse": "%s",
     "efunc": "%s",
     "ecls": "%s"
@@ -27,6 +28,8 @@
     "bool": "%s = bool(%s)"
   },
   "BLOCK_KEYWORDS": {
-    "blk": "\n"
+    "el": "else: %s\n",
+    "func": "def %s:\n",
+    "cls": "class %s:\n"
   }
 }


### PR DESCRIPTION
Add brackets syntax aside from pair syntax. Remove current block command `block` and `blk`.
- Pair syntax:
```
"for1": "i in range(10)",
"out1": "i",
"efor1": ""
```
- Brackets syntax:
```
"for1": [
    "i in range(10)",
    { "out1": "i" }
]
```
Some advantages from this new syntax:
- Reduce frequency of command offset - out"1" for example.
- Create more compact code.